### PR TITLE
Changed makefile and usage.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,44 +5,42 @@
 #	$(X)	expansion of variable X
 # 	make -C lets you specify a directory to call `make` in
 
-# Variables
-COMPILER = gcc
-GCC_FLAGS = -g -Wall
-ARCHIVE = ar
-AR_FLAGS = rvs
+.DEFAULT_GOAL := libhashtable.a
+PREFIX = /usr/local
 
-INCLUDE_PATHS = \
--I ./include/ \
+CC 		= gcc
+CFLAGS 	= -g -Wall -Iinclude
+ARFLAGS	= rvs
 
-EXECUTABLES = \
-test
+override CFLAGS += -Iinclude
 
-LIBRARY_PATHS = \
-hash_table.a
+OBJ = HashTable.o HNode.o 
+BIN = test
 
-OBJECT_FILES = \
-HashTable.o \
-HNode.o 
-
-# Convenience Rules
-all: target
-target: test
+.PHONY: all clean install uninstall
+all: $(.DEFAULT_GOAL) install $(BIN)
 
 # Object Compilation
-%.o: ./source/%.c ./include/%.h
-	$(COMPILER) $(INCLUDE_PATHS) $(GCC_FLAGS) -c $< -o $@	
+%.o: source/%.c include/%.h
+	$(CC) $(CFLAGS) -c $< -o $@	
 
 # Executables
-test: test.o $(OBJECT_FILES)
-	$(COMPILER) $(INCLUDE_PATHS) $(GCC_FLAGS) $^ -o $@
+test: source/test.c
+	$(CC) $(CFLAGS) $< -o $@ -lhashtable
 
 # Library
-hash_table.a: $(OBJECT_FILES)
-	$(ARCHIVE) $(AR_FLAGS) $@ $^
+libhashtable.a: $(OBJ)
+	$(AR) $(ARFLAGS) $@ $^
 
-# Clean
+install:
+	install -d $(PREFIX)/lib $(PREFIX)/include/hashtable
+	install -m 0644 libhashtable.a $(PREFIX)/lib
+	install -m 0644 include/*.h $(PREFIX)/include/hashtable
+
+uninstall:
+	rm -f $(PREFIX)/lib/libhashtable.a
+	rm -rf $(PREFIX)/include/hashtable
+
 clean:
-	rm -rf test.o
-	rm -rf $(EXECUTABLES)
-	rm -rf $(LIBRARY_PATHS)
-	rm -rf $(OBJECT_FILES)
+	rm -f libhashtable.a
+	rm -rf $(BIN) $(OBJ)

--- a/include/HNode.h
+++ b/include/HNode.h
@@ -1,8 +1,6 @@
 #ifndef __HNode
 #define __HNode
 
-#include <stdlib.h>
-
 typedef void (* DeleteData)(void *);
 
 // This struct and the functions declared in this file are not to be used by clients of HashTable. 

--- a/include/HashTable.h
+++ b/include/HashTable.h
@@ -1,6 +1,9 @@
 #ifndef __HASH_TABLE
 #define __HASH_TABLE
 
+#include <stdint.h>
+#include <pthread.h>
+
 #include <HNode.h>
 
 typedef uint32_t (* HashFunc)(const void *, size_t);

--- a/include/HashTable.h
+++ b/include/HashTable.h
@@ -2,9 +2,6 @@
 #define __HASH_TABLE
 
 #include <HNode.h>
-#include <stdlib.h>
-#include <stdint.h>
-#include <pthread.h>
 
 typedef uint32_t (* HashFunc)(const void *, size_t);
 typedef int (* EqualityFunc)(void *, void *);

--- a/readme.md
+++ b/readme.md
@@ -1,20 +1,36 @@
-# Read Me
+# hash\_table
 
 ## Description
 
 This is a thread-safe, generic hashtable implementation in C. 
 
-See `./sources/test.c` for usage. 
+See `source/test.c` for usage.
 
 ## Features
 
 - Custom key and value types
 - Thread-safe
 - Simple, consistent API
-- Compiles to .a library for use in other project
+- Compiles to .a library for use in other projects
 
-## Integratation
+## Compiling
 
-1. Use `make hash_table.a` to compile project to library
-2. Add `./include/` to your header search path
-3. When compiling project link against `./hash_table.a`
+1. Use `make` to create the static library. (`libhashtable.a`)
+2. Use `sudo make install` to install the library and header files to PREFIX.
+3. Use the clean rule to remove the new files: `make clean`.
+
+## Usage
+
+You can get the headers from the `hashtable` folder like this:
+
+```C
+#include <hashtable/HashTable.h>
+#include <hashtable/HNode.h>
+```
+
+When compiling your files, add the library to your flags: `-lhashtable`.
+
+## Uninstalling
+
+Use the makefile's uninstall rule: `sudo make uninstall`. It'll remove the
+files from PREFIX.

--- a/source/HNode.c
+++ b/source/HNode.c
@@ -1,5 +1,7 @@
-#include <HNode.h>
 #include <stdio.h>
+#include <stdlib.h>
+
+#include <HNode.h>
 
 // returns pointer to HNode on success. 0 on failure
 HNode * hnode_new(

--- a/source/HashTable.c
+++ b/source/HashTable.c
@@ -3,9 +3,9 @@
 
 // private interface
 
-void _hashtable_resize(HashTable * h_table);
-uint32_t _hashtable_hash_adler32(const void *buf, size_t buflength);
-int _hashtable_replace(
+static void _hashtable_resize(HashTable * h_table);
+static uint32_t _hashtable_hash_adler32(const void *buf, size_t buflength);
+static int _hashtable_replace(
 	HashTable * h_table, 
 	void * key, size_t key_len, 
 	void * value, size_t value_len
@@ -127,7 +127,7 @@ void * hashtable_get(HashTable * h_table, void * key, size_t key_len) {
 	return ret_val;
 }
 
-int _hashtable_replace(
+static int _hashtable_replace(
 	HashTable * h_table, 
 	void * key, size_t key_len, 
 	void * value, size_t value_len
@@ -182,7 +182,7 @@ void hashtable_remove(HashTable * h_table, void * key, size_t key_len) {
 	pthread_mutex_unlock(ht_mutex);
 }
 
-void _hashtable_resize(HashTable * h_table) {
+static void _hashtable_resize(HashTable * h_table) {
 	int size = h_table->size;
 	int new_size = (int)(h_table->size * h_table->resize_factor);
 	HNode ** new_table = calloc(sizeof(HNode *), new_size);
@@ -248,7 +248,7 @@ http://stackoverflow.com/a/14409947/3158248
 
 Please note, that the rest of the code is my own.
 */
-uint32_t _hashtable_hash_adler32(const void *buf, size_t buflength) {
+static uint32_t _hashtable_hash_adler32(const void *buf, size_t buflength) {
      const uint8_t *buffer = (const uint8_t*)buf;
 
      uint32_t s1 = 1;

--- a/source/HashTable.c
+++ b/source/HashTable.c
@@ -1,5 +1,10 @@
-#include <HashTable.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <pthread.h>
+
+#include <HNode.h>
+#include <HashTable.h>
 
 // private interface
 

--- a/source/test.c
+++ b/source/test.c
@@ -1,6 +1,7 @@
 #include <string.h>
 #include <stdio.h>
-#include <HashTable.h>
+
+#include <hashtable/HashTable.h>
 
 int equal_string(void * a, void * b) {
 	char * str1 = (char *) a;


### PR DESCRIPTION
The private interface is now also genuinely private, by making use of C's `static` keyword. The Makefile was updated to follow a library-oriented approach, which I think might be overdoing it for a simple data structure implementation, so sorry if that's not what you intended.

`make test` should probably depend on install, since it relies on the library being installed for the test program to be compiled.
